### PR TITLE
SA-1919 Add build namespaces in gabbar & veeru for running pipelines

### DIFF
--- a/stage-prod/tenant-operator-config/tenants/gabbar.yaml
+++ b/stage-prod/tenant-operator-config/tenants/gabbar.yaml
@@ -21,5 +21,11 @@ spec:
       template: tenant-vault-access
       sync: true
   namespaces:
+  - build
   - stage
   - prod
+  specificMetadata:
+    - namespaces:
+        - gabbar-build
+      annotations:
+        openshift.io/node-selector: node-role.kubernetes.io/pipeline=

--- a/stage-prod/tenant-operator-config/tenants/gabbar.yaml
+++ b/stage-prod/tenant-operator-config/tenants/gabbar.yaml
@@ -15,7 +15,7 @@ spec:
     sourceRepos:
       - 'https://github.com/stakater/nordmart-infra-gitops-config'
       - 'https://github.com/stakater/nordmart-apps-gitops-config'
-      - 'https://nexus-helm-stakater-nexus.apps.devtest.vxdqgl7u.kubeapp.cloud/repository/helm-charts/'
+      - 'https://nexus-helm-stakater-nexus.apps.stage.2cc6dtsv.kubeapp.cloud/repository/helm-charts/'
   templateInstances:
   - spec:
       template: tenant-vault-access

--- a/stage-prod/tenant-operator-config/tenants/veeru.yaml
+++ b/stage-prod/tenant-operator-config/tenants/veeru.yaml
@@ -12,7 +12,7 @@ spec:
     sourceRepos:
       - 'https://github.com/stakater/nordmart-apps-gitops-config'
       - 'https://github.com/stakater/nordmart-infra-gitops-config'
-      - 'https://nexus-helm-stakater-nexus.apps.devtest.vxdqgl7u.kubeapp.cloud/repository/helm-charts/'
+      - 'https://nexus-helm-stakater-nexus.apps.stage.2cc6dtsv.kubeapp.cloud/repository/helm-charts/'
   templateInstances:
   - spec:
       template: tenant-vault-access

--- a/stage-prod/tenant-operator-config/tenants/veeru.yaml
+++ b/stage-prod/tenant-operator-config/tenants/veeru.yaml
@@ -18,5 +18,11 @@ spec:
       template: tenant-vault-access
       sync: true
   namespaces:
+  - build
   - stage
   - prod
+  specificMetadata:
+    - namespaces:
+        - veeru-build
+      annotations:
+        openshift.io/node-selector: node-role.kubernetes.io/pipeline=


### PR DESCRIPTION
We aim to run **tekton pipelines** in **stage** environment so that we have a stable version of pipelines running at all times. To run pipelines in stage, **we need build namespaces**, which were presently missing in stage environment, adding config **to add build namespace in gabbar and veeru on stage**. Also updating nexus routes.