### PR TITLE
[devtest:clustertasks] disable showing the commands as log SA-1791

### DIFF
--- a/dev-test/clustertasks/stakater-app-sync-and-wait-v1.yaml
+++ b/dev-test/clustertasks/stakater-app-sync-and-wait-v1.yaml
@@ -56,6 +56,7 @@ spec:
       script: |
         TENANT=$(echo $(params.namespace) | cut -d'-' -f 1)
         COMMIT_HASH=`echo -n $(params.IMAGE_TAG) | tail -c 8`
+        set +x
         
         # PR Merged into Main Branch 
         if [ $(params.prNumber) = "NA" ]; then


### PR DESCRIPTION
Disable showing the commands as log because it exposes argocd username and password
![argocd-pass](https://user-images.githubusercontent.com/101177975/196432525-c8d04056-01ee-41fe-8b80-39ae0457861c.png)
