### PR TITLE
bumps mattermost version to 0.1.24

### DIFF
--- a/dev-test/argocd-apps/mattermost-instance.yaml
+++ b/dev-test/argocd-apps/mattermost-instance.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     chart: mattermost-instance
     repoURL: https://stakater.github.io/stakater-charts
-    targetRevision: 0.1.22
+    targetRevision: 0.1.24
     helm:
       releaseName: mattermost-instance
       values: |


### PR DESCRIPTION
Bumps mattermost version to 0.1.24. in stakater/charts actions auto bump version to new instance . we need to update here also